### PR TITLE
Passing row to getColumnValue, so column can have a sortBy function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 coverage
-dist

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,8 @@
+export declare type Direction = 'ASC' | 'DESC';
+export declare type SortArray<T> = [keyof T, Direction][];
+export declare type SortObject<T> = {
+    [key in keyof T]?: Direction;
+};
+export declare type GetColumnValue<T> = (column: keyof T, value: T[keyof T], row: T) => any;
+declare const multiColumnSort: <T>(arr: T[], sortArrOrObject: SortArray<T> | SortObject<T>, getColumnValue?: GetColumnValue<T> | undefined) => T[];
+export default multiColumnSort;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,44 @@
+"use strict";
+var __spreadArray = (this && this.__spreadArray) || function (to, from) {
+    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
+        to[j] = from[i];
+    return to;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var sort = function (a, b, columns, getColumnValue) {
+    var item = columns[0], others = columns.slice(1);
+    var column = item[0], orderBy = item[1];
+    var valueA = getColumnValue ? getColumnValue(column, a[column], a) : a[column];
+    var valueB = getColumnValue ? getColumnValue(column, b[column], b) : b[column];
+    if (orderBy === 'ASC') {
+        if (valueA > valueB)
+            return 1;
+        if (valueA < valueB)
+            return -1;
+        if (others.length)
+            return sort(a, b, others, getColumnValue);
+        return 0;
+    }
+    else {
+        if (valueB > valueA)
+            return 1;
+        if (valueB < valueA)
+            return -1;
+        if (others.length)
+            return sort(a, b, others, getColumnValue);
+        return 0;
+    }
+};
+var sortObjectToArray = function (object) {
+    return Object.keys(object).reduce(function (arr, column) {
+        return __spreadArray(__spreadArray([], arr), [[column, object[column]]]);
+    }, []);
+};
+var multiColumnSort = function (arr, sortArrOrObject, getColumnValue) {
+    return __spreadArray([], arr).sort(function (a, b) {
+        return sort(a, b, Array.isArray(sortArrOrObject)
+            ? sortArrOrObject
+            : sortObjectToArray(sortArrOrObject), getColumnValue);
+    });
+};
+exports.default = multiColumnSort;

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 export type Direction = 'ASC' | 'DESC'
 export type SortArray<T> = [keyof T, Direction][]
 export type SortObject<T> = { [key in keyof T]?: Direction }
-export type GetColumnValue<T> = (column: keyof T, value: T[keyof T]) => any
+export type GetColumnValue<T> = (column: keyof T, value: T[keyof T], row: T) => any
 
 const sort = <T>(
   a: T,
@@ -11,8 +11,8 @@ const sort = <T>(
 ): -1 | 0 | 1 => {
   const [item, ...others] = columns
   const [column, orderBy] = item
-  const valueA = getColumnValue ? getColumnValue(column, a[column]) : a[column]
-  const valueB = getColumnValue ? getColumnValue(column, b[column]) : b[column]
+  const valueA = getColumnValue ? getColumnValue(column, a[column], a) : a[column]
+  const valueB = getColumnValue ? getColumnValue(column, b[column], b) : b[column]
 
   if (orderBy === 'ASC') {
     if (valueA > valueB) return 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-column-sort",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Tiny multi column sorting JS helper",
   "author": "Dmitrijs Čuvikovs <chuvikovd@gmail.com> (https://chuva.dev)",
   "repository": "https://github.com/chuvikovd/multi-column-sort",


### PR DESCRIPTION
I'm using `multi-column-sort` to sort a table of data, which has columns and rows. I'd like the columns to be able to use a custom `sortBy` function, which can perhaps return a calculated value based on other data in the row. Therefore, the `getColumnValue` function needs to receive the entire row.

It can then be left up to the user to set up their `getColumnValue` function to make use of the row and possible sortBy function. 

In my case I'm working on a React app, and the columns are an array stored in state. `multi-column-sort` does not receive the columns array, so in my `getColumnValue` function I filter the columns from state and choose the one that matches.

For example here's some of the code from my React app:

```
let columns = [
    { name: 'Name', selector: 'name', sortable: true },
    { name: 'Gender', selector: 'gender', sortable: true },
    { name: 'Age', selector: 'age', sortable: true, sortBy: (column, value, row)=>{
        // here I'm just returning the name instead of age, but you could make any calculation you want
        return row.name
    } },
];
...
const [state_columns,setState_columns] = useState( (columns || []) );
...
let getColumnValue = (columnName, value, row) => {
    let sortingColumn = state_columns.filter(col=>col.selector === columnName);
    if ( sortingColumn[0].sortBy ) {
        return sortingColumn[0].sortBy(columnName, value, row);
    } else {
        return value;
    }
};
```

